### PR TITLE
Add createViewModelScope extension for Activities

### DIFF
--- a/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/ActivityViewModelLazy.kt
+++ b/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/ActivityViewModelLazy.kt
@@ -1,0 +1,19 @@
+package uk.co.conjure.viewmodelscope
+
+import androidx.activity.ComponentActivity
+import androidx.activity.viewModels
+import androidx.annotation.MainThread
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+
+@MainThread
+inline fun <reified VM : ViewModel> ComponentActivity.createViewModelScope(
+    noinline extrasProducer: (() -> CreationExtras)? = null,
+    noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
+): Lazy<VM> = viewModels<VM>(extrasProducer, factoryProducer).also {
+    ViewModelStoreOwnerRegistry.instance.put(VM::class, this)
+    VM::class.java.interfaces.forEach {
+        ViewModelStoreOwnerRegistry.instance.registerInterface(it.kotlin, VM::class)
+    }
+}

--- a/app/src/main/java/uk/co/conjure/vmscopedemo/MainActivity.kt
+++ b/app/src/main/java/uk/co/conjure/vmscopedemo/MainActivity.kt
@@ -3,8 +3,10 @@ package uk.co.conjure.vmscopedemo
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.activity.viewModels
+import uk.co.conjure.viewmodelscope.createViewModelScope
 import uk.co.conjure.vmscopedemo.ui.main.NavigationViewModel
 import uk.co.conjure.vmscopedemo.ui.main.Screen
+import uk.co.conjure.vmscopedemo.ui.main.screens.first.ActivityViewModel
 import uk.co.conjure.vmscopedemo.ui.main.screens.first.ParentFragment
 import uk.co.conjure.vmscopedemo.ui.main.screens.second.OtherFragment
 
@@ -18,9 +20,13 @@ private const val SECOND_FRAGMENT_TAG = "SECOND_FRAGMENT"
 class MainActivity : AppCompatActivity() {
 
     private val navigationViewModel: NavigationViewModel by viewModels()
+    private val activityViewModel: ActivityViewModel by createViewModelScope()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        activityViewModel.setMessage("This is coming from the Activity")
+
         setContentView(R.layout.activity_main)
 
         navigationViewModel.currentScreen.observe(this) { screen ->

--- a/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/first/ActivityViewModel.kt
+++ b/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/first/ActivityViewModel.kt
@@ -1,0 +1,17 @@
+package uk.co.conjure.vmscopedemo.ui.main.screens.first
+
+import androidx.lifecycle.ViewModel
+
+interface ActivityChildViewModel {
+    val activityMessage: String
+}
+
+class ActivityViewModel : ViewModel(), ActivityChildViewModel {
+    private var _message: String = ""
+    override val activityMessage: String
+        get() = _message
+
+    fun setMessage(message: String) {
+        _message = message
+    }
+}

--- a/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/second/OtherFragment.kt
+++ b/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/second/OtherFragment.kt
@@ -4,15 +4,20 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import uk.co.conjure.viewmodelscope.scopedInterface
+import uk.co.conjure.vmscopedemo.R
 import uk.co.conjure.vmscopedemo.databinding.FragmentOtherBinding
 import uk.co.conjure.vmscopedemo.ui.main.NavigationViewModel
+import uk.co.conjure.vmscopedemo.ui.main.screens.first.ActivityChildViewModel
 
 class OtherFragment : Fragment() {
 
     private val navigationViewModel: NavigationViewModel by activityViewModels()
+    private val activityChildViewModel: ActivityChildViewModel by scopedInterface()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -22,6 +27,7 @@ class OtherFragment : Fragment() {
             it.btnOpenFirstScreen.setOnClickListener {
                 navigationViewModel.showFirstScreen()
             }
+            it.tvActivityMessage.text = activityChildViewModel.activityMessage
         }.root
     }
 

--- a/app/src/main/res/layout/fragment_other.xml
+++ b/app/src/main/res/layout/fragment_other.xml
@@ -6,6 +6,7 @@
     tools:context=".ui.main.screens.second.OtherFragment">
 
     <TextView
+        android:id="@+id/tv_activity_message"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"


### PR DESCRIPTION
Added an extension function ComponentActivity.createViewModelScope()

Works just like Fragment.createViewModelScope()