### PR TITLE
Add support for extra fragment key inside createViewModelScope

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 [![](https://jitpack.io/v/conjure/ScopedViewModel.svg)](https://jitpack.io/#conjure/ScopedViewModel)
 
+## Including the library
+
+Add `jitpack.io` to your repositories in your **projects** `build.gradle` file.
+```gradle
+allprojects {
+		repositories {
+			...
+			maven { url 'https://jitpack.io' }
+		}
+	}
+```
+Add ScopedViewModel to your dependencies of your module.
 ```gradle
 dependencies {
   implementation 'com.github.conjure:ScopedViewModel:TAG'

--- a/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/ActivityViewModelLazy.kt
+++ b/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/ActivityViewModelLazy.kt
@@ -7,13 +7,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
 
+//TODO add support for a custom key
 @MainThread
 inline fun <reified VM : ViewModel> ComponentActivity.createViewModelScope(
     noinline extrasProducer: (() -> CreationExtras)? = null,
     noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
-): Lazy<VM> = viewModels<VM>(extrasProducer, factoryProducer).also {
-    ViewModelStoreOwnerRegistry.instance.put(VM::class, this)
-    VM::class.java.interfaces.forEach {
-        ViewModelStoreOwnerRegistry.instance.registerInterface(it.kotlin, VM::class)
-    }
-}
+): Lazy<VM> = viewModels<VM>(extrasProducer, factoryProducer)
+    .also { putOwnerInRegistry<VM>(DEFAULT_KEY, this) }

--- a/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/ActivityViewModelLazy.kt
+++ b/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/ActivityViewModelLazy.kt
@@ -7,10 +7,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
 
-//TODO add support for a custom key
+
 @MainThread
 inline fun <reified VM : ViewModel> ComponentActivity.createViewModelScope(
+    extraKey: String? = null,
     noinline extrasProducer: (() -> CreationExtras)? = null,
     noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
 ): Lazy<VM> = viewModels<VM>(extrasProducer, factoryProducer)
-    .also { putOwnerInRegistry<VM>(DEFAULT_KEY, this) }
+    .also { putOwnerInRegistry<VM>(extraKey ?: DEFAULT_KEY, this) }

--- a/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/CommonViewModelLazy.kt
+++ b/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/CommonViewModelLazy.kt
@@ -1,8 +1,6 @@
 package uk.co.conjure.viewmodelscope
 
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 
@@ -30,26 +28,6 @@ inline fun <reified VM : ViewModel> putOwnerInRegistry(extraKey: String, owner: 
     VM::class.java.interfaces.forEach {
         ViewModelStoreOwnerRegistry.instance.registerInterface(it.kotlin, extraKey, VM::class)
     }
-}
-
-/**
- * You shouldn't need to call this directly.
- */
-inline fun <reified VM : ViewModel> Fragment.registerFragmentOnCreate(
-    crossinline fragmentFinder: () -> Fragment?,
-    crossinline fragmentProducer: () -> Fragment,
-    key: String
-) {
-    lifecycle.addObserver(object : DefaultLifecycleObserver {
-        override fun onCreate(owner: LifecycleOwner) {
-            if (fragmentFinder() == null) {
-                childFragmentManager.beginTransaction()
-                    .add(fragmentProducer(), key)
-                    .commitNow()
-            }
-            putOwnerInRegistry<VM>(key, fragmentProducer())
-        }
-    })
 }
 
 /**

--- a/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/CommonViewModelLazy.kt
+++ b/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/CommonViewModelLazy.kt
@@ -1,0 +1,60 @@
+package uk.co.conjure.viewmodelscope
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
+
+/**
+ * You should not need to reference this directly.
+ *
+ * The key used as a tag in the childFragmentManager to store the ViewModelStoreOwner. And passed
+ * in a Bundle to the child Fragment to retrieve the ViewModelStoreOwner.
+ */
+const val KEY_EXTRA_KEY = "uk.co.conjure.viewmodelscope.EXTRA_KEY"
+
+/**
+ * You should not need to reference this directly.
+ *
+ * The default key used as a tag in the childFragmentManager to store the ViewModelStoreOwner if no
+ * extraKey is provided.
+ */
+const val DEFAULT_KEY = "uk.co.conjure.viewmodelscope.DEFAULT_KEY"
+
+/**
+ * You shouldn't need to call this directly.
+ */
+inline fun <reified VM : ViewModel> putOwnerInRegistry(extraKey: String, owner: ViewModelStoreOwner) {
+    ViewModelStoreOwnerRegistry.instance.put(VM::class, extraKey, owner)
+    VM::class.java.interfaces.forEach {
+        ViewModelStoreOwnerRegistry.instance.registerInterface(it.kotlin, extraKey, VM::class)
+    }
+}
+
+/**
+ * You shouldn't need to call this directly.
+ */
+inline fun <reified VM : ViewModel> Fragment.registerFragmentOnCreate(
+    crossinline fragmentFinder: () -> Fragment?,
+    crossinline fragmentProducer: () -> Fragment,
+    key: String
+) {
+    lifecycle.addObserver(object : DefaultLifecycleObserver {
+        override fun onCreate(owner: LifecycleOwner) {
+            if (fragmentFinder() == null) {
+                childFragmentManager.beginTransaction()
+                    .add(fragmentProducer(), key)
+                    .commitNow()
+            }
+            putOwnerInRegistry<VM>(key, fragmentProducer())
+        }
+    })
+}
+
+/**
+ * You should not need to call this directly. It is called by [scopedInterface] and [scopedViewModel].
+ * If you have added a key to the arguments of the fragment, it will use that key to retrieve the
+ * ViewModelStoreOwner. Otherwise it will use the default key.
+ */
+fun Fragment.getViewModelKey(): String = arguments?.getString(KEY_EXTRA_KEY) ?: DEFAULT_KEY

--- a/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/ViewModelStoreOwnerRegistry.kt
+++ b/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/ViewModelStoreOwnerRegistry.kt
@@ -25,13 +25,12 @@ class ViewModelStoreOwnerRegistry private constructor() {
     /**
      * A map from the view model class name to a second map of the extra key to the ViewModelStoreOwner.
      */
-    private val map = hashMapOf<String, MutableMap<String, WeakReference<ViewModelStoreOwner>>>()
+    private val map = hashMapOf<ViewModelClass, WeakReference<ViewModelStoreOwner>>()
 
     /**
      * A map from the interface KClass to a second map of the extra key to the ViewModel KClass.
      */
-    private val interfaceMap =
-        hashMapOf<KClass<out Any>, MutableMap<String, KClass<out ViewModel>>>()
+    private val interfaceMap = hashMapOf<Interface, KClass<out ViewModel>>()
 
     fun <VM : ViewModel> put(
         viewModelClass: KClass<VM>,
@@ -39,8 +38,7 @@ class ViewModelStoreOwnerRegistry private constructor() {
         owner: ViewModelStoreOwner
     ) {
         viewModelClass.qualifiedName?.let { className ->
-            if (map.containsKey(className)) map[className]?.put(extraKey, WeakReference(owner))
-            else map[className] = hashMapOf(extraKey to WeakReference(owner))
+            map[ViewModelClass(className, extraKey)] = WeakReference(owner)
         }
     }
 
@@ -48,21 +46,24 @@ class ViewModelStoreOwnerRegistry private constructor() {
         viewModelClass: KClass<VM>,
         extraKey: String
     ): ViewModelStoreOwner? {
-        return map[viewModelClass.qualifiedName]?.get(extraKey)?.get()
+        return map[ViewModelClass(viewModelClass.qualifiedName!!, extraKey)]?.get()
     }
 
     fun <VM : ViewModel> registerInterface(
-        register: KClass<out Any>,
-        extraKey: String,
-        with: KClass<VM>
+        interfaceClass: KClass<out Any>,
+        key: String,
+        viewModelClass: KClass<VM>
     ) {
-        val registered = interfaceMap[register]?.get(extraKey)
-        if (registered != null && registered != with) throw IllegalStateException("Can not register more than one ViewModel with the Interface $register.")
-        if (interfaceMap.containsKey(register)) interfaceMap[register]?.put(extraKey, with)
-        else interfaceMap[register] = hashMapOf(extraKey to with)
+        val interfaceKey = Interface(interfaceClass, key)
+        val registered = interfaceMap[interfaceKey]
+        if (registered != null && registered != viewModelClass) throw IllegalStateException("Can not register more than one ViewModel with the Interface $interfaceClass and key $key.")
+        interfaceMap[interfaceKey] = viewModelClass
     }
 
-    fun getViewModel(myInterface: KClassifier, extraKey: String?): KClass<out ViewModel>? {
-        return interfaceMap[myInterface]?.get(extraKey)
+    fun getViewModel(myInterface: KClassifier, extraKey: String): KClass<out ViewModel>? {
+        return interfaceMap[Interface(myInterface, extraKey)]
     }
+
+    data class Interface(val interfaceClass: KClassifier, val key: String)
+    data class ViewModelClass(val className: String, val key: String)
 }

--- a/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/ViewModelStoreOwnerRegistry.kt
+++ b/ViewModelScope/src/main/java/uk/co/conjure/viewmodelscope/ViewModelStoreOwnerRegistry.kt
@@ -22,25 +22,47 @@ class ViewModelStoreOwnerRegistry private constructor() {
         val instance: ViewModelStoreOwnerRegistry by lazy { ViewModelStoreOwnerRegistry() }
     }
 
-    private val map: MutableMap<String, WeakReference<ViewModelStoreOwner>> = hashMapOf()
+    /**
+     * A map from the view model class name to a second map of the extra key to the ViewModelStoreOwner.
+     */
+    private val map = hashMapOf<String, MutableMap<String, WeakReference<ViewModelStoreOwner>>>()
 
-    private val interfaceMap: MutableMap<KClass<out Any>, KClass<out ViewModel>> = mutableMapOf()
+    /**
+     * A map from the interface KClass to a second map of the extra key to the ViewModel KClass.
+     */
+    private val interfaceMap =
+        hashMapOf<KClass<out Any>, MutableMap<String, KClass<out ViewModel>>>()
 
-    fun <VM : ViewModel> put(viewModelClass: KClass<VM>, owner: ViewModelStoreOwner) {
-        map[viewModelClass.qualifiedName!!] = WeakReference(owner)
+    fun <VM : ViewModel> put(
+        viewModelClass: KClass<VM>,
+        extraKey: String,
+        owner: ViewModelStoreOwner
+    ) {
+        viewModelClass.qualifiedName?.let { className ->
+            if (map.containsKey(className)) map[className]?.put(extraKey, WeakReference(owner))
+            else map[className] = hashMapOf(extraKey to WeakReference(owner))
+        }
     }
 
-    fun <VM : ViewModel> get(viewModelClass: KClass<VM>): ViewModelStoreOwner? {
-        return map[viewModelClass.qualifiedName]?.get()
+    fun <VM : ViewModel> get(
+        viewModelClass: KClass<VM>,
+        extraKey: String
+    ): ViewModelStoreOwner? {
+        return map[viewModelClass.qualifiedName]?.get(extraKey)?.get()
     }
 
-    fun <VM : ViewModel> registerInterface(register: KClass<out Any>, with: KClass<VM>) {
-        val registered = interfaceMap[register]
+    fun <VM : ViewModel> registerInterface(
+        register: KClass<out Any>,
+        extraKey: String,
+        with: KClass<VM>
+    ) {
+        val registered = interfaceMap[register]?.get(extraKey)
         if (registered != null && registered != with) throw IllegalStateException("Can not register more than one ViewModel with the Interface $register.")
-        interfaceMap[register] = with
+        if (interfaceMap.containsKey(register)) interfaceMap[register]?.put(extraKey, with)
+        else interfaceMap[register] = hashMapOf(extraKey to with)
     }
 
-    fun getViewModel(myInterface: KClassifier): KClass<out ViewModel>? {
-        return interfaceMap[myInterface]
+    fun getViewModel(myInterface: KClassifier, extraKey: String?): KClass<out ViewModel>? {
+        return interfaceMap[myInterface]?.get(extraKey)
     }
 }

--- a/app/src/main/java/uk/co/conjure/vmscopedemo/MainActivity.kt
+++ b/app/src/main/java/uk/co/conjure/vmscopedemo/MainActivity.kt
@@ -8,10 +8,13 @@ import uk.co.conjure.vmscopedemo.ui.main.NavigationViewModel
 import uk.co.conjure.vmscopedemo.ui.main.Screen
 import uk.co.conjure.vmscopedemo.ui.main.screens.first.ActivityViewModel
 import uk.co.conjure.vmscopedemo.ui.main.screens.first.ParentFragment
+import uk.co.conjure.vmscopedemo.ui.main.screens.multifragment.MultiChildFragment
+import uk.co.conjure.vmscopedemo.ui.main.screens.multifragment.MultiFragmentFragment
 import uk.co.conjure.vmscopedemo.ui.main.screens.second.OtherFragment
 
 private const val FIRST_FRAGMENT_TAG = "FIRST_FRAGMENT"
 private const val SECOND_FRAGMENT_TAG = "SECOND_FRAGMENT"
+private const val MULTI_FRAGMENT_TAG = "MULTI_FRAGMENT_TAG"
 
 /**
  * The MainActivity subscribes to the [NavigationViewModel.currentScreen] to switch between
@@ -33,6 +36,7 @@ class MainActivity : AppCompatActivity() {
             when (screen) {
                 Screen.FIRST -> showFirstScreen()
                 Screen.SECOND -> showSecondScreen()
+                Screen.MULTIFRAGMENT -> showMultifragmentScreen()
                 null -> {} // ignore
             }
         }
@@ -51,6 +55,14 @@ class MainActivity : AppCompatActivity() {
         if (supportFragmentManager.findFragmentByTag(SECOND_FRAGMENT_TAG) == null) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.container, OtherFragment(), SECOND_FRAGMENT_TAG)
+                .commitNow()
+        }
+    }
+
+    private fun showMultifragmentScreen() {
+        if (supportFragmentManager.findFragmentByTag(MULTI_FRAGMENT_TAG) == null) {
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.container, MultiFragmentFragment(), MULTI_FRAGMENT_TAG)
                 .commitNow()
         }
     }

--- a/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/NavigationViewModel.kt
+++ b/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/NavigationViewModel.kt
@@ -7,12 +7,15 @@ import androidx.lifecycle.ViewModel
 interface AppNavigation {
     fun showFirstScreen()
     fun showSecondScreen()
+    fun showMultifragmentScreen()
+
     val currentScreen: LiveData<Screen>
 }
 
 enum class Screen {
     FIRST,
-    SECOND
+    SECOND,
+    MULTIFRAGMENT
 }
 
 class NavigationViewModel : ViewModel(), AppNavigation {
@@ -25,5 +28,9 @@ class NavigationViewModel : ViewModel(), AppNavigation {
 
     override fun showSecondScreen() {
         currentScreen.value = Screen.SECOND
+    }
+
+    override fun showMultifragmentScreen() {
+        currentScreen.value = Screen.MULTIFRAGMENT
     }
 }

--- a/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/first/ParentFragment.kt
+++ b/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/first/ParentFragment.kt
@@ -69,6 +69,10 @@ class ParentFragment : Fragment() {
         binding.btnOpenOtherScreen.setOnClickListener {
             navigationViewModel.showSecondScreen()
         }
+
+        binding.btnOpenMultifragmentScreen.setOnClickListener {
+            navigationViewModel.showMultifragmentScreen()
+        }
     }
 
     private fun attachChildFragment() {

--- a/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/multifragment/ChildViewModel.kt
+++ b/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/multifragment/ChildViewModel.kt
@@ -1,0 +1,12 @@
+package uk.co.conjure.vmscopedemo.ui.main.screens.multifragment
+
+import androidx.lifecycle.ViewModel
+import kotlin.random.Random
+
+interface ChildViewModel {
+    val number: Int
+}
+
+class ChildViewModelImpl : ViewModel(), ChildViewModel {
+    override val number: Int by lazy { Random(System.nanoTime()).nextInt(100000) }
+}

--- a/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/multifragment/MultiChildFragment.kt
+++ b/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/multifragment/MultiChildFragment.kt
@@ -1,0 +1,36 @@
+package uk.co.conjure.vmscopedemo.ui.main.screens.multifragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import uk.co.conjure.viewmodelscope.scopedInterface
+import uk.co.conjure.viewmodelscope.scopedViewModel
+import uk.co.conjure.vmscopedemo.databinding.FragmentMultiChildBinding
+
+class MultiChildFragment : Fragment() {
+    private val viewModel: ChildViewModel by scopedInterface()
+
+    private var _binding: FragmentMultiChildBinding? = null
+    private val binding: FragmentMultiChildBinding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return FragmentMultiChildBinding.inflate(inflater, container, false)
+            .also { fragmentMainBinding -> this._binding = fragmentMainBinding }
+            .root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        binding.tvNumber.text = viewModel.number.toString()
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+}

--- a/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/multifragment/MultiFragmentFragment.kt
+++ b/app/src/main/java/uk/co/conjure/vmscopedemo/ui/main/screens/multifragment/MultiFragmentFragment.kt
@@ -1,0 +1,69 @@
+package uk.co.conjure.vmscopedemo.ui.main.screens.multifragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import uk.co.conjure.viewmodelscope.addViewModelKey
+import uk.co.conjure.viewmodelscope.createViewModelScope
+import uk.co.conjure.vmscopedemo.databinding.FragmentMultiFragmentParentBinding
+import uk.co.conjure.vmscopedemo.ui.main.NavigationViewModel
+
+private const val CHILD_1_TAG = "CHILD_1_TAG"
+
+class MultiFragmentFragment : Fragment() {
+
+    private val child1ViewModelKey = "child1ViewModelKey"
+    private val child2ViewModelKey = "child2ViewModelKey"
+
+    private var _binding: FragmentMultiFragmentParentBinding? = null
+    private val binding: FragmentMultiFragmentParentBinding get() = _binding!!
+
+    private val navigationViewModel: NavigationViewModel by activityViewModels()
+
+    init {
+        createViewModelScope<ChildViewModelImpl>(child1ViewModelKey)
+        createViewModelScope<ChildViewModelImpl>(child2ViewModelKey)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return FragmentMultiFragmentParentBinding.inflate(inflater, container, false)
+            .also { fragmentMainBinding -> this._binding = fragmentMainBinding }
+            .root
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        binding.btnGoTo.setOnClickListener {
+            navigationViewModel.showFirstScreen()
+        }
+
+        //inflate two child fragments into the root linear layout in binding
+        if (childFragmentManager.findFragmentByTag(CHILD_1_TAG) == null) {
+            childFragmentManager.beginTransaction()
+                .add(
+                    binding.fragmentContainer.id,
+                    MultiChildFragment::class.java,
+                    Bundle().addViewModelKey(child1ViewModelKey),
+                    CHILD_1_TAG
+                )
+                .add(
+                    binding.fragmentContainer.id,
+                    MultiChildFragment::class.java,
+                    Bundle().addViewModelKey(child2ViewModelKey)
+                )
+                .commit()
+        }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+}

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -34,7 +34,7 @@
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
         android:text="@string/open_child"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/btn_open_multifragment_screen"
         app:layout_constraintEnd_toStartOf="@id/btn_open_other_screen"
         app:layout_constraintStart_toStartOf="parent" />
 
@@ -44,9 +44,19 @@
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
         android:text="@string/other_screen"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/btn_open_multifragment_screen"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/btn_open_child" />
+
+    <Button
+        android:id="@+id/btn_open_multifragment_screen"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="@string/multifragment_screen"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <androidx.cardview.widget.CardView
         android:id="@+id/cv_child_container"

--- a/app/src/main/res/layout/fragment_multi_child.xml
+++ b/app/src/main/res/layout/fragment_multi_child.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="160dp"
+    android:layout_margin="16dp"
+    app:cardElevation="10dp"
+    app:cardCornerRadius="8dp">
+
+    <TextView
+        android:id="@+id/tv_number"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/fragment_multi_fragment_parent.xml
+++ b/app/src/main/res/layout/fragment_multi_fragment_parent.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"/>
+
+    <Button
+        android:id="@+id/btn_go_to_"
+        android:layout_width="match_parent"
+        android:layout_margin="16dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:text="@string/open_first_screen" />
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="click_me">Click Me</string>
+    <string name="multifragment_screen">MultiFragment Screen</string>
 </resources>


### PR DESCRIPTION
Currently ComponentActivity.createViewModelScope does not support adding an extra key. This will need to be explored and implemented in a different PR I think.

Also due to the fact that the functions are declared inline it's not possible for them to call any code that is declared private or internal as this would essentially mean the call site was calling private/internal code which would not be allowed by the compiler. This is an issue with inline as it kind of infects everything. I separated the code into separate functions for clarity, but this now means there are publicly exposed functions that should really be marked internal. I moved all such code to a new file called CommonViewModelLazy. Another approach would be to duplicate the code and just copy it directly into the inline function bodies, but i thought this was a bit better. Everything that shouldn't be called by the outside world should be documented as such at least.